### PR TITLE
Reduce generated image size and layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,23 @@
 FROM ubuntu:16.04
 MAINTAINER info@intermediaware.de
 
-RUN apt-get update
-RUN apt-get -y install git
-RUN apt-get -y install openssl libssl-dev
-RUN apt-get -y install build-essential
-RUN apt-get -y install vim
-RUN apt-get -y install curl
+RUN apt-get update \
+    && apt-get -y install git \
+    && apt-get -y install openssl libssl-dev \
+    && apt-get -y install build-essential \
+    && apt-get -y install vim \
+    && apt-get -y install curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && git clone https://github.com/jorisvink/kore.git /kore \
+    && cd /kore \
+    && make NOTLS=1 DEBUG=1 NOOPT=1 \
+    && make install NOTLS=1 DEBUG=1 NOOPT=1 \
+    && rm -rf /kore \
+    && apt-get -y purge git build-essential
 
-WORKDIR /
-RUN git clone https://github.com/jorisvink/kore.git
-WORKDIR /kore
-
-RUN make NOTLS=1 DEBUG=1 NOOPT=1
-RUN make install NOTLS=1 DEBUG=1 NOOPT=1
-
-WORKDIR /
 ADD ./my_app /my_app
-
 WORKDIR /my_app
 
 EXPOSE 8888
 
 CMD ["kodev", "run"]
-


### PR DESCRIPTION
With this PR both the size of the image and amount of layers are reduced

* **Before**
```
Layers:       24
Size:     483 MB
```
* **After**
```
Layers:       13
Size:     409 MB
```

Another point to keep things small and snappy would be to
* Try to use alpine as base image instead of ubuntu (~120MB difference)
* Use *ADD https://github.com/jorisvink/kore/releases/download/2.0.0-release/kore-2.0.0-release.tar.gz* and stick with the binary instead of installing all build-tools, git and compile it yourself (although **release 2.0.0** != **branch master**)